### PR TITLE
Trim whitespace around URL in cst-config.xml

### DIFF
--- a/solution/CST/cst.ktr
+++ b/solution/CST/cst.ktr
@@ -463,7 +463,7 @@
         <group/>
         <length>-1</length>
         <precision>-1</precision>
-        <trim_type>none</trim_type>
+        <trim_type>both</trim_type>
         <repeat>N</repeat>
       </field>
       <field>


### PR DESCRIPTION
If there is whitespace around a tab URL in cst-config.xml, the ajax call
in the loadTabs function in template.html would fail with an
unexpected_token error.  Trimming whitespace from the URL when loading
the xml file fixes it.
