### PR TITLE
Open tabs quickly when using fullScreen mode

### DIFF
--- a/solution/CST/template.html
+++ b/solution/CST/template.html
@@ -153,6 +153,16 @@
     processAndClose: function(){
       //Dashboards.log("Closing");
       var myself=this;
+      var timeout = 1000;
+      if (0 == myself.tabs.length) {
+        timeout = 0;
+      }
+      $.each(myself.tabs, function(i, tab) {
+        // if there are any fullscreen tabs, open them quickly
+        if (tab[2]) {
+          timeout = 0;
+        }
+      });
       $("#cstLine1").animate({left: "0%", width:"50%" },3000)
       $("#cstLine2").animate({left: "50%", width:"50%" },3000)
       setTimeout(function(){
@@ -160,8 +170,8 @@
         setTimeout(function(){
           myself.openTabs();
           parent.closeTab(window.location.href)
-        },1000)
-      }, 1000)
+        }, timeout)
+      },  timeout)
     }
 
   });


### PR DESCRIPTION
If the fullScreen attribute is set to true on any of the tabs, open the
tabs quickly by setting the timeouts to zero in the processAndClose
method.
